### PR TITLE
Add info nodes for Point, Sun, Spot and Area lights

### DIFF
--- a/customnodes/__init__.py
+++ b/customnodes/__init__.py
@@ -4,6 +4,10 @@
 
 
 from . camerainfo import NODEBOOSTER_NG_camerainfo
+from . point_lightinfo import NODEBOOSTER_NG_point_lightinfo
+from . sun_lightinfo import NODEBOOSTER_NG_sun_lightinfo
+from . spot_lightinfo import NODEBOOSTER_NG_spot_lightinfo
+from . area_lightinfo import NODEBOOSTER_NG_area_lightinfo
 from . isrenderedview import NODEBOOSTER_NG_isrenderedview
 from . sequencervolume import NODEBOOSTER_NG_sequencervolume
 from . mathexpression import NODEBOOSTER_NG_mathexpression
@@ -16,6 +20,10 @@ from . pynexscript import NODEBOOSTER_NG_pynexscript
 classes = (
 
     NODEBOOSTER_NG_camerainfo,
+    NODEBOOSTER_NG_point_lightinfo,
+    NODEBOOSTER_NG_sun_lightinfo,
+    NODEBOOSTER_NG_spot_lightinfo,
+    NODEBOOSTER_NG_area_lightinfo,
     NODEBOOSTER_NG_isrenderedview,
     NODEBOOSTER_NG_sequencervolume,
     NODEBOOSTER_NG_mathexpression,

--- a/customnodes/area_lightinfo.py
+++ b/customnodes/area_lightinfo.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 BD3D DIGITAL DESIGN (Dorian B.), Andrew Stevenson
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+import bpy
+
+from ..__init__ import get_addon_prefs
+from ..utils.str_utils import word_wrap
+from ..utils.node_utils import create_new_nodegroup, set_socket_defvalue
+
+
+class NODEBOOSTER_NG_area_lightinfo(bpy.types.GeometryNodeCustomGroup):
+    """Custom Nodegroup: Gather informations about any area light.
+    • Expect updates on each depsgraph post and frame_pre update signals"""
+
+    bl_idname = "GeometryNodeNodeBoosterAreaLightInfo"
+    bl_label = "Area Light Info"
+
+    def light_obj_poll(self, obj):
+        return obj.type == 'LIGHT' and obj.data.type == 'AREA'
+
+    light_obj: bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        poll=light_obj_poll,
+        )
+
+    @classmethod
+    def poll(cls, context):
+        """mandatory poll"""
+        return True
+
+    def init(self, context):
+        """this fct run when appending the node for the first time"""
+
+        name = f".{self.bl_idname}"
+
+        ng = bpy.data.node_groups.get(name)
+        if (ng is None):
+            ng = create_new_nodegroup(name,
+                out_sockets={
+                    "Area Light" : "NodeSocketObject",
+                    "Color" : "NodeSocketColor",
+                    "Power" : "NodeSocketFloat",
+                    "Shape" : "NodeSocketString",
+                    "Size X" : "NodeSocketFloat",
+                    "Size Y" : "NodeSocketFloat",
+                },
+            )
+
+        ng = ng.copy() #always using a copy of the original ng
+
+        self.node_tree = ng
+        self.label = self.bl_label
+
+        return None
+
+    def copy(self, node):
+        """fct run when dupplicating the node"""
+
+        self.node_tree = node.node_tree.copy()
+
+        return None
+
+    def update(self):
+        """generic update function"""
+
+        scene = bpy.context.scene
+        light_obj = self.light_obj
+
+        if (light_obj and light_obj.type == 'LIGHT' and light_obj.data and light_obj.data.type == 'AREA'):
+            set_socket_defvalue(self.node_tree, 0, value=light_obj)
+            set_socket_defvalue(self.node_tree, 1, value=[light_obj.data.color[0], light_obj.data.color[1], light_obj.data.color[2], 1.0])
+            set_socket_defvalue(self.node_tree, 2, value=light_obj.data.energy)
+            set_socket_defvalue(self.node_tree, 3, value=light_obj.data.shape)
+            set_socket_defvalue(self.node_tree, 4, value=light_obj.data.size)
+            set_socket_defvalue(self.node_tree, 5, value=light_obj.data.size_y)
+        else:
+            set_socket_defvalue(self.node_tree, 0, value=None)
+            set_socket_defvalue(self.node_tree, 1, value=[0.0, 0.0, 0.0, 0.0])
+            set_socket_defvalue(self.node_tree, 2, value=0.0)
+            set_socket_defvalue(self.node_tree, 3, value="")
+            set_socket_defvalue(self.node_tree, 4, value=0.0)
+            set_socket_defvalue(self.node_tree, 5, value=0.0)
+
+        return None
+
+    def draw_label(self,):
+        """node label"""
+
+        return self.bl_label
+
+    def draw_buttons(self, context, layout):
+        """node interface drawing"""
+
+        row = layout.row(align=True)
+        sub = row.row(align=True)
+
+        sub.prop(self, "light_obj", text="", icon="LIGHT_AREA")
+
+        return None
+
+    @classmethod
+    def update_all_instances(cls, from_depsgraph=False,):
+        """search for all nodes of this type and update them"""
+
+        all_instances = [n for ng in bpy.data.node_groups for n in ng.nodes if (n.bl_idname==cls.bl_idname)]
+        for n in all_instances:
+            n.update()
+
+        return None

--- a/customnodes/point_lightinfo.py
+++ b/customnodes/point_lightinfo.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 BD3D DIGITAL DESIGN (Dorian B.), Andrew Stevenson
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+import bpy
+
+from ..__init__ import get_addon_prefs
+from ..utils.str_utils import word_wrap
+from ..utils.node_utils import create_new_nodegroup, set_socket_defvalue
+
+
+class NODEBOOSTER_NG_point_lightinfo(bpy.types.GeometryNodeCustomGroup):
+    """Custom Nodegroup: Gather informations about any point light.
+    • Expect updates on each depsgraph post and frame_pre update signals"""
+
+    bl_idname = "GeometryNodeNodeBoosterPointLightInfo"
+    bl_label = "Point Light Info"
+
+    def light_obj_poll(self, obj):
+        return obj.type == 'LIGHT' and obj.data.type == 'POINT'
+
+    light_obj: bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        poll=light_obj_poll,
+        )
+
+    @classmethod
+    def poll(cls, context):
+        """mandatory poll"""
+        return True
+
+    def init(self, context):
+        """this fct run when appending the node for the first time"""
+
+        name = f".{self.bl_idname}"
+
+        ng = bpy.data.node_groups.get(name)
+        if (ng is None):
+            ng = create_new_nodegroup(name,
+                out_sockets={
+                    "Point Light" : "NodeSocketObject",
+                    "Color" : "NodeSocketColor",
+                    "Power" : "NodeSocketFloat",
+                    "Soft Falloff" : "NodeSocketBool",
+                    "Radius" : "NodeSocketFloat",
+                },
+            )
+
+        ng = ng.copy() #always using a copy of the original ng
+
+        self.node_tree = ng
+        self.label = self.bl_label
+
+        return None
+
+    def copy(self, node):
+        """fct run when dupplicating the node"""
+
+        self.node_tree = node.node_tree.copy()
+
+        return None
+
+    def update(self):
+        """generic update function"""
+
+        scene = bpy.context.scene
+        light_obj = self.light_obj
+
+        if (light_obj and light_obj.type == 'LIGHT' and light_obj.data and light_obj.data.type == 'POINT'):
+            set_socket_defvalue(self.node_tree, 0, value=light_obj)
+            set_socket_defvalue(self.node_tree, 1, value=[light_obj.data.color[0], light_obj.data.color[1], light_obj.data.color[2], 1.0])
+            set_socket_defvalue(self.node_tree, 2, value=light_obj.data.energy)
+            set_socket_defvalue(self.node_tree, 3, value=light_obj.data.use_soft_falloff)
+            set_socket_defvalue(self.node_tree, 4, value=light_obj.data.shadow_soft_size)
+        else:
+            set_socket_defvalue(self.node_tree, 0, value=None)
+            set_socket_defvalue(self.node_tree, 1, value=[0.0, 0.0, 0.0, 0.0])
+            set_socket_defvalue(self.node_tree, 2, value=0.0)
+            set_socket_defvalue(self.node_tree, 3, value=False)
+            set_socket_defvalue(self.node_tree, 4, value=0.0)
+
+        return None
+
+    def draw_label(self,):
+        """node label"""
+
+        return self.bl_label
+
+    def draw_buttons(self, context, layout):
+        """node interface drawing"""
+
+        row = layout.row(align=True)
+        sub = row.row(align=True)
+
+        sub.prop(self, "light_obj", text="", icon="LIGHT_POINT")
+
+        return None
+
+    @classmethod
+    def update_all_instances(cls, from_depsgraph=False,):
+        """search for all nodes of this type and update them"""
+
+        all_instances = [n for ng in bpy.data.node_groups for n in ng.nodes if (n.bl_idname==cls.bl_idname)]
+        for n in all_instances:
+            n.update()
+
+        return None

--- a/customnodes/spot_lightinfo.py
+++ b/customnodes/spot_lightinfo.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 BD3D DIGITAL DESIGN (Dorian B.), Andrew Stevenson
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+import bpy
+
+from ..__init__ import get_addon_prefs
+from ..utils.str_utils import word_wrap
+from ..utils.node_utils import create_new_nodegroup, set_socket_defvalue
+
+
+class NODEBOOSTER_NG_spot_lightinfo(bpy.types.GeometryNodeCustomGroup):
+    """Custom Nodegroup: Gather informations about any spot light.
+    • Expect updates on each depsgraph post and frame_pre update signals"""
+
+    bl_idname = "GeometryNodeNodeBoosterSpotLightInfo"
+    bl_label = "Spot Light Info"
+
+    def light_obj_poll(self, obj):
+        return obj.type == 'LIGHT' and obj.data.type == 'SPOT'
+
+    light_obj: bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        poll=light_obj_poll,
+        )
+
+    @classmethod
+    def poll(cls, context):
+        """mandatory poll"""
+        return True
+
+    def init(self, context):
+        """this fct run when appending the node for the first time"""
+
+        name = f".{self.bl_idname}"
+
+        ng = bpy.data.node_groups.get(name)
+        if (ng is None):
+            ng = create_new_nodegroup(name,
+                out_sockets={
+                    "Spot Light" : "NodeSocketObject",
+                    "Color" : "NodeSocketColor",
+                    "Power" : "NodeSocketFloat",
+                    "Soft Falloff" : "NodeSocketBool",
+                    "Radius" : "NodeSocketFloat",
+                    "Beam Size" : "NodeSocketFloat",
+                    "Beam Blend" : "NodeSocketFloat",
+                    "Beam Show Cone" : "NodeSocketBool",
+                },
+            )
+
+        ng = ng.copy() #always using a copy of the original ng
+
+        self.node_tree = ng
+        self.label = self.bl_label
+
+        return None
+
+    def copy(self, node):
+        """fct run when dupplicating the node"""
+
+        self.node_tree = node.node_tree.copy()
+
+        return None
+
+    def update(self):
+        """generic update function"""
+
+        scene = bpy.context.scene
+        light_obj = self.light_obj
+
+        if (light_obj and light_obj.type == 'LIGHT' and light_obj.data and light_obj.data.type == 'AREA'):
+            set_socket_defvalue(self.node_tree, 0, value=light_obj)
+            set_socket_defvalue(self.node_tree, 1, value=[light_obj.data.color[0], light_obj.data.color[1], light_obj.data.color[2], 1.0])
+            set_socket_defvalue(self.node_tree, 2, value=light_obj.data.energy)
+            set_socket_defvalue(self.node_tree, 3, value=light_obj.data.use_soft_falloff)
+            set_socket_defvalue(self.node_tree, 4, value=light_obj.data.shadow_soft_size)
+            set_socket_defvalue(self.node_tree, 5, value=light_obj.data.spot_size)
+            set_socket_defvalue(self.node_tree, 6, value=light_obj.data.spot_blend)
+            set_socket_defvalue(self.node_tree, 7, value=light_obj.data.show_cone)
+        else:
+            set_socket_defvalue(self.node_tree, 0, value=None)
+            set_socket_defvalue(self.node_tree, 1, value=[0.0, 0.0, 0.0, 0.0])
+            set_socket_defvalue(self.node_tree, 2, value=0.0)
+            set_socket_defvalue(self.node_tree, 3, value=False)
+            set_socket_defvalue(self.node_tree, 4, value=0.0)
+            set_socket_defvalue(self.node_tree, 5, value=0.0)
+            set_socket_defvalue(self.node_tree, 6, value=0.0)
+            set_socket_defvalue(self.node_tree, 7, value=False)
+
+        return None
+
+    def draw_label(self,):
+        """node label"""
+
+        return self.bl_label
+
+    def draw_buttons(self, context, layout):
+        """node interface drawing"""
+
+        row = layout.row(align=True)
+        sub = row.row(align=True)
+
+        sub.prop(self, "light_obj", text="", icon="LIGHT_SPOT")
+
+        return None
+
+    @classmethod
+    def update_all_instances(cls, from_depsgraph=False,):
+        """search for all nodes of this type and update them"""
+
+        all_instances = [n for ng in bpy.data.node_groups for n in ng.nodes if (n.bl_idname==cls.bl_idname)]
+        for n in all_instances:
+            n.update()
+
+        return None

--- a/customnodes/sun_lightinfo.py
+++ b/customnodes/sun_lightinfo.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 BD3D DIGITAL DESIGN (Dorian B.), Andrew Stevenson
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+import bpy
+
+from ..__init__ import get_addon_prefs
+from ..utils.str_utils import word_wrap
+from ..utils.node_utils import create_new_nodegroup, set_socket_defvalue
+
+
+class NODEBOOSTER_NG_sun_lightinfo(bpy.types.GeometryNodeCustomGroup):
+    """Custom Nodegroup: Gather informations about any sun light.
+    • Expect updates on each depsgraph post and frame_pre update signals"""
+
+    bl_idname = "GeometryNodeNodeBoosterSunLightInfo"
+    bl_label = "Sun Light Info"
+
+    def light_obj_poll(self, obj):
+        return obj.type == 'LIGHT' and obj.data.type == 'SUN'
+
+    light_obj: bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        poll=light_obj_poll,
+        )
+
+    @classmethod
+    def poll(cls, context):
+        """mandatory poll"""
+        return True
+
+    def init(self, context):
+        """this fct run when appending the node for the first time"""
+
+        name = f".{self.bl_idname}"
+
+        ng = bpy.data.node_groups.get(name)
+        if (ng is None):
+            ng = create_new_nodegroup(name,
+                out_sockets={
+                    "Sun Light" : "NodeSocketObject",
+                    "Color" : "NodeSocketColor",
+                    "Strength" : "NodeSocketFloat",
+                    "Angle" : "NodeSocketFloat",
+                },
+            )
+
+        ng = ng.copy() #always using a copy of the original ng
+
+        self.node_tree = ng
+        self.label = self.bl_label
+
+        return None
+
+    def copy(self, node):
+        """fct run when dupplicating the node"""
+
+        self.node_tree = node.node_tree.copy()
+
+        return None
+
+    def update(self):
+        """generic update function"""
+
+        scene = bpy.context.scene
+        light_obj = self.light_obj
+
+        if (light_obj and light_obj.type == 'LIGHT' and light_obj.data and light_obj.data.type == 'SUN'):
+            set_socket_defvalue(self.node_tree, 0, value=light_obj)
+            set_socket_defvalue(self.node_tree, 1, value=[light_obj.data.color[0], light_obj.data.color[1], light_obj.data.color[2], 1.0])
+            set_socket_defvalue(self.node_tree, 2, value=light_obj.data.energy)
+            set_socket_defvalue(self.node_tree, 3, value=light_obj.data.angle)
+        else:
+            set_socket_defvalue(self.node_tree, 0, value=None)
+            set_socket_defvalue(self.node_tree, 1, value=[0.0, 0.0, 0.0, 0.0])
+            set_socket_defvalue(self.node_tree, 2, value=0.0)
+            set_socket_defvalue(self.node_tree, 3, value=0.0)
+
+        return None
+
+    def draw_label(self,):
+        """node label"""
+
+        return self.bl_label
+
+    def draw_buttons(self, context, layout):
+        """node interface drawing"""
+
+        row = layout.row(align=True)
+        sub = row.row(align=True)
+
+        sub.prop(self, "light_obj", text="", icon="LIGHT_SUN")
+
+        return None
+
+    @classmethod
+    def update_all_instances(cls, from_depsgraph=False,):
+        """search for all nodes of this type and update them"""
+
+        all_instances = [n for ng in bpy.data.node_groups for n in ng.nodes if (n.bl_idname==cls.bl_idname)]
+        for n in all_instances:
+            n.update()
+
+        return None

--- a/handlers.py
+++ b/handlers.py
@@ -11,6 +11,10 @@ from .__init__ import get_addon_prefs
 from .operators.palette import msgbus_palette_callback
 from .customnodes import (
     NODEBOOSTER_NG_camerainfo,
+    NODEBOOSTER_NG_point_lightinfo,
+    NODEBOOSTER_NG_sun_lightinfo,
+    NODEBOOSTER_NG_spot_lightinfo,
+    NODEBOOSTER_NG_area_lightinfo,
     NODEBOOSTER_NG_pyexpression,
     NODEBOOSTER_NG_sequencervolume,
     NODEBOOSTER_NG_isrenderedview,
@@ -81,6 +85,12 @@ def nodebooster_handler_depspost(scene,desp):
     #need to update camera nodes outputs
     NODEBOOSTER_NG_camerainfo.update_all_instances(from_depsgraph=True)
 
+    #need to update light nodes outputs
+    NODEBOOSTER_NG_point_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_sun_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_spot_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_area_lightinfo.update_all_instances(from_depsgraph=True)
+
     #automatic re-evaluation of the Python Expression and Python Nex Nodes.
     #for security reasons, only if the user allows it expressively on each program session.
     if (sett_win.allow_auto_pyexec):
@@ -102,6 +112,12 @@ def nodebooster_handler_framepre(scene,desp):
 
     #need to update camera nodes outputs
     NODEBOOSTER_NG_camerainfo.update_all_instances(from_depsgraph=True)
+
+    #need to update light nodes outputs
+    NODEBOOSTER_NG_point_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_sun_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_spot_lightinfo.update_all_instances(from_depsgraph=True)
+    NODEBOOSTER_NG_area_lightinfo.update_all_instances(from_depsgraph=True)
 
     #need to update all volume sequencer nodes output value
     NODEBOOSTER_NG_sequencervolume.update_all_instances(from_depsgraph=True)


### PR DESCRIPTION
This pull request adds info nodes for point, sun, spot and area lights as we discussed on the forums.  We are using point and sun for a geometry nodes tree to do vertex lighting and being able to manipulate the light objects directly, to update the lighting, is better than updating node tree values.  I added spot and area to cover all 4 kinds of lights but I currently don't have a use for them.